### PR TITLE
fix(version): propery ldflag path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
       - -s
       - -w
       ## <<Stencil::Block(onceLdflags)>>
-      - -X github.com/jaredallard/once/cmd/once.Version={{ .Version }}
+      - -X main.Version={{ .Version }}
       ## <</Stencil::Block>>
     env:
       - CGO_ENABLED=0

--- a/cmd/once/once.go
+++ b/cmd/once/once.go
@@ -36,7 +36,8 @@ import (
 
 const developmentVersion = "v0.0.0-dev"
 
-// Version contains the current version of the CLI, which gets overwritten during releases (see .goreleaser.yml).
+// Version contains the current version of the CLI, which gets
+// overwritten during releases (see .goreleaser.yml).
 var Version = developmentVersion
 
 // entrypoint is the main logic of the CLI.


### PR DESCRIPTION
When using `main` you must not include the `trimpath` prefix
(confusingly), so we have to do `main.Version`.

This can be tested with the following:

```bash
$ goreleaser --clean --snapshot
$ ./dist/once_darwin_arm64_v8.0/once --version
once version 0.2.2-next
```
